### PR TITLE
constexpr double Hz = 0.5;

### DIFF
--- a/pandemic.h
+++ b/pandemic.h
@@ -11,7 +11,8 @@
 #include "event.h"
 
 /* Number of renderizations per clock tick */
-#define HZ 0.5
+//#define HZ 0.5
+constexpr double Hz = 0.5;
 
 struct comparator{
   bool operator()(Event& e1, Event& e2)


### PR DESCRIPTION
begin using constexpr instead of define macros